### PR TITLE
Adding support for secondary tile notifictions

### DIFF
--- a/lib/ruby-mpns.rb
+++ b/lib/ruby-mpns.rb
@@ -114,7 +114,7 @@ protected
 
     notification = '<?xml version="1.0" encoding="utf-8"?>'
     notification << '<wp:Notification xmlns:wp="WPNotification">'
-    notification <<   '<wp:Tile '
+    notification <<   '<wp:Tile' << ((options[:secondary_tile_uri])? ' id="' + coder.encode(options[:secondary_tile_uri]) + '"' : '') << '>'
     notification <<     '<wp:BackgroundImage>' << coder.encode(options[:background_image]) << '</wp:BackgroundImage>'
     notification <<     '<wp:Count>' << coder.encode(options[:count]) << '</wp:Count>'
     notification <<     '<wp:Title>' << coder.encode(options[:title]) << '</wp:Title>'


### PR DESCRIPTION
I believe that in the actual state of the repository, the Tile snippet is missing the closing bracket '>', specifically in line 117 of the ruby-mpns.rb file.

Furthermore, just closing the tag won't make the gem support secondary tiles as it omits the id attribute. In this pull request I fix the closing tag and implement a solution for the secondary tile support.
